### PR TITLE
#25 - 독서모임 상세페이지 수정

### DIFF
--- a/src/main/java/invincibleDevs/bookpago/readingClub/ProfileDTO.java
+++ b/src/main/java/invincibleDevs/bookpago/readingClub/ProfileDTO.java
@@ -1,0 +1,12 @@
+package invincibleDevs.bookpago.readingClub;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ProfileDTO {
+    private Long kakaoId;
+    private String nickname;
+    private String imgUrl;
+}

--- a/src/main/java/invincibleDevs/bookpago/readingClub/dto/ReadingClubRequest.java
+++ b/src/main/java/invincibleDevs/bookpago/readingClub/dto/ReadingClubRequest.java
@@ -3,7 +3,6 @@ package invincibleDevs.bookpago.readingClub.dto;
 import java.util.List;
 
 public record ReadingClubRequest(
-        Long id,
         Long kakaoId,
         String clubName,
         String location,

--- a/src/main/java/invincibleDevs/bookpago/readingClub/dto/ReadingClubResponse.java
+++ b/src/main/java/invincibleDevs/bookpago/readingClub/dto/ReadingClubResponse.java
@@ -1,0 +1,20 @@
+package invincibleDevs.bookpago.readingClub.dto;
+
+import invincibleDevs.bookpago.readingClub.ProfileDTO;
+
+import java.util.List;
+
+public record ReadingClubResponse(
+        Long id,
+        Long adminId,
+        int members,
+        String clubName,
+        String location,
+        String description,
+        String time,
+        int repeatCycle,
+        List<Integer> weekDay,
+        List<ProfileDTO> memberList,
+        List<ProfileDTO> applicantList
+) {
+}

--- a/src/main/java/invincibleDevs/bookpago/readingClub/repository/ReadingClubMapRepository.java
+++ b/src/main/java/invincibleDevs/bookpago/readingClub/repository/ReadingClubMapRepository.java
@@ -30,4 +30,16 @@ public interface ReadingClubMapRepository extends JpaRepository<ReadingClubMap,L
     // 특정 독서 모임(clubId)에서 특정 프로필이 clubApplicant로 있는지 확인
     @Query("SELECT rc FROM ReadingClubMap rc WHERE rc.readingClub.id = :clubId AND rc.clubApplicant = :profile")
     Optional<ReadingClubMap> findByIdAndApplicant(@Param("clubId") Long clubId, @Param("profile") Profile profile);
+
+    // 특정 독서 모임(clubId)에서 멤버 리스트 조회
+    @Query("SELECT rc FROM ReadingClubMap rc WHERE rc.readingClub.id = :clubId AND rc.clubMember IS NOT NULL")
+    List<ReadingClubMap> findMembersByClubId(@Param("clubId") Long clubId);
+
+    // 특정 독서 모임(clubId)에서 대기자 리스트 조회
+    @Query("SELECT rc FROM ReadingClubMap rc WHERE rc.readingClub.id = :clubId AND rc.clubApplicant IS NOT NULL")
+    List<ReadingClubMap> findApplicantsByClubId(@Param("clubId") Long clubId);
+
+    // 특정 독서 모임(clubId)에서 관리자 조회
+    @Query("SELECT rc FROM ReadingClubMap rc WHERE rc.readingClub.id = :clubId AND rc.clubAdmin IS NOT NULL")
+    Optional<ReadingClubMap> findAdminByClubId(@Param("clubId") Long clubId);
 }

--- a/src/main/java/invincibleDevs/bookpago/readingClub/service/ReadingClubFacade.java
+++ b/src/main/java/invincibleDevs/bookpago/readingClub/service/ReadingClubFacade.java
@@ -5,6 +5,7 @@ import invincibleDevs.bookpago.profile.service.ProfileService;
 import invincibleDevs.bookpago.readingClub.dto.ReadingClubDto;
 import invincibleDevs.bookpago.readingClub.dto.ReadingClubMapRequest;
 import invincibleDevs.bookpago.readingClub.dto.ReadingClubRequest;
+import invincibleDevs.bookpago.readingClub.dto.ReadingClubResponse;
 import invincibleDevs.bookpago.readingClub.model.ReadingClub;
 import invincibleDevs.bookpago.readingClub.model.ReadingClubMap;
 import invincibleDevs.bookpago.readingClub.repository.ReadingClubMapRepository;
@@ -48,19 +49,25 @@ public class ReadingClubFacade {
         return new PageImpl<>(clubDtos, pageable, readingClubsPage.getTotalElements());
     }
 
-    public ReadingClubDto getClub(Long clubId) {
+    public ReadingClubResponse getClub(Long clubId) {
         ReadingClub readingClub = readingClubService.findById(clubId);
+        Optional<ReadingClubMap> adminMapOptional = readingClubMapRepository.findAdminByClubId(clubId);
+        Long adminId = 0L;
+        if (adminMapOptional.isPresent()) { adminId = adminMapOptional.get().getClubAdmin().getUserEntity().getKakaoId(); }
         // Dto 변환 코드 (레코드 타입 사용)
         // ReadingClubMap의 갯수 구하기
-        return new ReadingClubDto(
+        return new ReadingClubResponse(
                 readingClub.getId(),
+                adminId,
                 readingClubService.getMemberCount(readingClub),
                 readingClub.getClubName(),
                 readingClub.getLocation(),
                 readingClub.getDescription(),
                 readingClub.getTime(),
                 readingClub.getRepeatCycle(),
-                readingClub.getWeekDay()
+                readingClub.getWeekDay(),
+                readingClubMapService.getMemberProfiles(clubId),
+                readingClubMapService.getApplicantProfiles(clubId)
         );
     }
 

--- a/src/main/java/invincibleDevs/bookpago/readingClub/service/ReadingClubMapService.java
+++ b/src/main/java/invincibleDevs/bookpago/readingClub/service/ReadingClubMapService.java
@@ -1,12 +1,14 @@
 package invincibleDevs.bookpago.readingClub.service;
 
 import invincibleDevs.bookpago.profile.model.Profile;
+import invincibleDevs.bookpago.readingClub.ProfileDTO;
 import invincibleDevs.bookpago.readingClub.dto.ReadingClubDto;
 import invincibleDevs.bookpago.readingClub.model.ReadingClub;
 import invincibleDevs.bookpago.readingClub.model.ReadingClubMap;
 import invincibleDevs.bookpago.readingClub.repository.ReadingClubMapRepository;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -101,5 +103,53 @@ public class ReadingClubMapService {
                 .readingClub(readingClub)
                 .build();
         return readingClubMapRepository.save(readingClubMap);
+    }
+
+    public List<ProfileDTO> getMemberProfiles(Long clubId) {
+        List<ProfileDTO> memberProfiles = new ArrayList<>();
+
+        // 관리자 정보를 맴버 리스트에 추가
+        Optional<ReadingClubMap> adminMapOptional = readingClubMapRepository.findAdminByClubId(clubId);
+        if (adminMapOptional.isPresent()) {
+            Profile adminProfile = adminMapOptional.get().getClubAdmin();
+            ProfileDTO adminDto = new ProfileDTO(
+                    adminProfile.getUserEntity().getKakaoId(),
+                    adminProfile.getNickName(),
+                    adminProfile.getProfileImgUrl()
+            );
+            memberProfiles.add(adminDto);
+        }
+
+        // 맴버 정보를 맴버 리스트에 추가
+        List<ReadingClubMap> memberMaps = readingClubMapRepository.findMembersByClubId(clubId);
+        for (ReadingClubMap memberMap : memberMaps) {
+            Profile memberProfile = memberMap.getClubMember();
+            ProfileDTO memberDto = new ProfileDTO(
+                    memberProfile.getUserEntity().getKakaoId(),
+                    memberProfile.getNickName(),
+                    memberProfile.getProfileImgUrl()
+            );
+            memberProfiles.add(memberDto);
+        }
+
+        return memberProfiles;
+    }
+
+    public List<ProfileDTO> getApplicantProfiles(Long clubId) {
+        List<ProfileDTO> applicantProfiles = new ArrayList<>();
+
+        // 맴버 정보를 맴버 리스트에 추가
+        List<ReadingClubMap> applicantMaps = readingClubMapRepository.findApplicantsByClubId(clubId);
+        for (ReadingClubMap applicantMap : applicantMaps) {
+            Profile applicantProfile = applicantMap.getClubApplicant();
+            ProfileDTO applicantDto = new ProfileDTO(
+                    applicantProfile.getUserEntity().getKakaoId(),
+                    applicantProfile.getNickName(),
+                    applicantProfile.getProfileImgUrl()
+            );
+            applicantProfiles.add(applicantDto);
+        }
+
+        return applicantProfiles;
     }
 }

--- a/src/main/java/invincibleDevs/bookpago/readingClub/service/ReadingClubService.java
+++ b/src/main/java/invincibleDevs/bookpago/readingClub/service/ReadingClubService.java
@@ -23,7 +23,6 @@ public class ReadingClubService {
             Set<ReadingClubMap> members) {
 
         ReadingClub readingClub = ReadingClub.builder()
-                                             .id(readingClubRequest.id())
                                              .clubMembers(members)
                                              .clubName(readingClubRequest.clubName())
                                              .description(readingClubRequest.description())


### PR DESCRIPTION
독서모임 상세페이지에 owerId, 맴버의 프로필 리스트, 대기자의 정보 리스트를 추가하기 위해 그에 맞는 메소드를 구현했다.